### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,10 @@ exports.extract = function (cwd, opts) {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
         var srcpath = path.resolve(cwd, header.linkname)
+        var relativePath = path.relative(cwd, srcpath)
+        if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+          return next(new Error('Invalid linkname: ' + header.linkname))
+        }
 
         xfs.link(srcpath, name, function (err) {
           if (err && err.code === 'EPERM' && opts.hardlinkAsFilesFallback) {


### PR DESCRIPTION
Potential fix for [https://github.com/lnbrown12399/code-scanning-javascript-demo/security/code-scanning/1](https://github.com/lnbrown12399/code-scanning-javascript-demo/security/code-scanning/1)

To fix the issue, we need to ensure that `header.linkname` is validated before being used in file system operations. Specifically, we should check that it does not contain directory traversal elements (`..`) or absolute paths. This can be achieved by normalizing the path and ensuring it remains within the intended directory (`cwd`). If the path is invalid, the operation should be skipped, and an error or warning should be logged.

The fix involves:
1. Adding a validation step for `header.linkname` before constructing `srcpath`.
2. Using `path.resolve` and `path.relative` to ensure the resolved path remains within `cwd`.
3. Skipping the operation if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
